### PR TITLE
Show counts for collapsed subnets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -109,6 +109,7 @@
                 const response = await axios.get('/api/sources');
                 const sources = response.data;
                 displaySources(sources);
+                filterSources();
             } catch (error) {
                 console.error('Error fetching sources:', error);
                 sourceList.innerHTML = '<p>Failed to fetch NDI sources</p>';
@@ -127,11 +128,21 @@
                 header.className = 'subnet-header';
                 header.textContent = subnet;
 
+                const countSpan = document.createElement('span');
+                countSpan.className = 'subnet-count';
+                header.appendChild(countSpan);
+
                 const hostContainer = document.createElement('div');
                 hostContainer.style.display = 'none';
 
+                const hostCount = Object.keys(hosts).length;
+                const sourceCount = Object.values(hosts).reduce((acc, arr) => acc + arr.length, 0);
+                countSpan.textContent = ` (${hostCount} hosts, ${sourceCount} sources)`;
+
                 header.addEventListener('click', () => {
-                    hostContainer.style.display = hostContainer.style.display === 'none' ? '' : 'none';
+                    const collapsed = hostContainer.style.display === 'none';
+                    hostContainer.style.display = collapsed ? '' : 'none';
+                    countSpan.textContent = collapsed ? '' : ` (${hostCount} hosts, ${sourceCount} sources)`;
                 });
 
                 for (const [instance, instanceSources] of Object.entries(hosts)) {
@@ -221,6 +232,7 @@
 
         // Initial fetch
         fetchSources();
+        setInterval(fetchSources, 5000);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show count of hosts and sources when a subnet group is collapsed
- keep search filter active on refresh
- auto refresh source list every 5 seconds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68789ef14fb483319927321ebcdf5f09