### PR TITLE
Implement subnet grouping rules

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,17 @@
 
         function groupBySubnet(sources) {
             return sources.reduce((acc, source) => {
-                const subnet = source.address.split('.').slice(0, 3).join('.') + '.0/24';
+                const parts = source.address.split('.');
+                let subnet;
+
+                if (parts[0] === '10' && parts[1] === '100') {
+                    subnet = parts.slice(0, 3).join('.') + '.0/24';
+                } else if (parts[0] === '10' && parts[1] === '64') {
+                    subnet = parts.slice(0, 2).join('.') + '.0.0/16';
+                } else {
+                    subnet = parts.slice(0, 3).join('.') + '.0/24';
+                }
+
                 if (!acc[subnet]) {
                     acc[subnet] = {};
                 }

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ DiscoBee is a free tool developed by ByteHive that simplifies viewing NDI — Ne
 - Currently supports localhost
 - Includes an API for programmatic access
 - Search for String in Source
+- Groups sources by subnet (/24 for 10.100.x.x and /16 for 10.64.x.x)
 ## Usage
 
 For Production environments, we recommend using one of the Prebuilt Binaries.


### PR DESCRIPTION
## Summary
- adjust grouping logic to allow different subnet sizes
- document subnet grouping behavior

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878d99ba6d48331a068823ec999479a