### PR TITLE
Handle closed socket errors

### DIFF
--- a/ndi-discovery-server.js
+++ b/ndi-discovery-server.js
@@ -124,6 +124,14 @@ const server = net.createServer((socket) => {
   const ip = socket.remoteAddress.replace(/^::ffff:/, '');
   hosts.set(socket, ip);
 
+  socket.on('error', (err) => {
+    if (err.code === 'EPIPE' || err.code === 'ECONNRESET') {
+      hosts.delete(socket);
+    } else {
+      console.error('Socket error', err);
+    }
+  });
+
   socket.on('data', async (data) => {
     const str = data.toString();
     if (str.includes('<query/>')) {


### PR DESCRIPTION
## Summary
- prevent server crash when a client disconnects

## Testing
- `npm run start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_687e0e229d2883318338d46665814db1