### PR TITLE
Add OAuth2 library

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express": "^4.19.2",
     "p3x-xml2json": "^2024.4.121",
     "xml2js": "^0.6.2",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "simple-oauth2": "^5.1.0"
   },
   "devDependencies": {
     "pkg": "^5.8.1"


### PR DESCRIPTION
## Summary
- add `simple-oauth2` as an OAuth2 dependency

## Testing
- `npm install simple-oauth2 --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68833c041a78833193b96281caaeac73