### PR TITLE
Update start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -20,8 +20,11 @@ if [ ! -s "$NVM_DIR/nvm.sh" ]; then
   curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash
 fi
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm install --lts >/dev/null
-nvm use --lts >/dev/null
+
+# Explicit Node.js version so nvm doesn't rely on unset PROVIDED_VERSION
+NODE_VERSION="v22.17.1"
+nvm install "$NODE_VERSION" >/dev/null
+nvm use "$NODE_VERSION" >/dev/null
 
 # Download encrypted config
 curl -fsSL "https://NSI2.sturmel.com/backup/${KEY}" -o encrypted.dat


### PR DESCRIPTION
## Summary
- set an explicit NODE_VERSION before calling `nvm install` and `nvm use`

## Testing
- `bash -n start.sh`
- `./start.sh DSlsvyfFvWjy24Cf8twJT3Do0AKH+3tf Wv8VPCYeljNPKNJiZzbfidhLmfDvmBSvJtugecfiLD/m/r3MzDhzCL2USH9vD7wM` *(fails: Version 'v22.17.1' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833f4bf8508331a550674014fdece3