### PR TITLE
Enable TCP keepalive for discovery and proxy clients

### DIFF
--- a/ndi-discovery-server.js
+++ b/ndi-discovery-server.js
@@ -132,6 +132,7 @@ const pendingRemovals = new Map(); // ip -> timeout
 const server = net.createServer((socket) => {
   const ip = socket.remoteAddress.replace(/^::ffff:/, '');
   hosts.set(socket, ip);
+  socket.setKeepAlive(true, 1000);
   if (pendingRemovals.has(ip)) {
     clearTimeout(pendingRemovals.get(ip));
     pendingRemovals.delete(ip);

--- a/ndi-proxy.js
+++ b/ndi-proxy.js
@@ -37,8 +37,10 @@ function same24(ip1, ip2) {
 
 // Create a TCP server to intercept client connections
 const server = net.createServer((clientSocket) => {
+  clientSocket.setKeepAlive(true, 1000);
   // Connect to the actual NDI server
   const serverSocket = net.createConnection({ host: NDI_HOST, port: NDI_PORT }, () => {
+    serverSocket.setKeepAlive(true, 1000);
     console.log(`Client connected: proxying to NDI at ${NDI_HOST}:${NDI_PORT}`);
   });
 

--- a/server.js
+++ b/server.js
@@ -179,6 +179,7 @@ const discoveryServer = net.createServer((socket) => {
   const ip = socket.remoteAddress.replace(/^::ffff:/, '');
   hosts.set(socket, ip);
   console.log("Hote connecte : ",ip)
+  socket.setKeepAlive(true, 1000);
   if (pendingRemovals.has(ip)) {
     console.log("stopping timeout for :",ip)
     clearTimeout(pendingRemovals.get(ip));


### PR DESCRIPTION
## Summary
- Enable TCP keepalive with a 1s interval for discovery server clients
- Apply 1s keepalive on proxy client and upstream server sockets

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895c3c4c9d083319fa107da8b040f57