### PR TITLE
fix: delay source removal until all host connections closed

### DIFF
--- a/ndi-discovery-server.js
+++ b/ndi-discovery-server.js
@@ -201,7 +201,7 @@ const server = net.createServer((socket) => {
         }
       }
       pendingRemovals.delete(ip);
-    }, 5000);
+    }, 60000);
     pendingRemovals.set(ip, timeout);
   });
 });

--- a/server.js
+++ b/server.js
@@ -238,14 +238,14 @@ const discoveryServer = net.createServer((socket) => {
   socket.on('close', () => {
     hosts.delete(socket);
     console.log("Connection closed ",ip)
-    //if ([...hosts.values()].includes(ip)) {
-    //  return; // another connection from this IP is still active
-    //}
-    console.log("strarting timeout for ",ip)
+    if ([...hosts.values()].includes(ip)) {
+      return; // another connection from this IP is still active
+    }
+    console.log("starting timeout for ",ip)
     const timeout = setTimeout(() => {
-      //if ([...hosts.values()].includes(ip)) {
-      //  return; // reconnected during delay
-      //}
+      if ([...hosts.values()].includes(ip)) {
+        return; // reconnected during delay
+      }
       console.log("removing for",ip)
       const removed = sources.filter((s) => s.owner === ip);
       sources = sources.filter((s) => s.owner !== ip);
@@ -258,7 +258,7 @@ const discoveryServer = net.createServer((socket) => {
         }
       }
       pendingRemovals.delete(ip);
-    }, 5000);
+    }, 60000);
     pendingRemovals.set(ip, timeout);
   });
 });


### PR DESCRIPTION
## Summary
- avoid prematurely removing NDI sources if a host still has an active connection
- wait one minute after the last disconnection before removing a host's sources

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895caddb27c8331add15a9bd8620337