### PR TITLE
Sort hosts by IP within subnet groups

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -262,7 +262,9 @@
                     localStorage.setItem('subnetState', JSON.stringify(subnetState));
                 });
 
-                for (const [instance, instanceSources] of Object.entries(hosts)) {
+                const sortedHosts = Object.entries(hosts)
+                    .sort(([ipA], [ipB]) => ipA.localeCompare(ipB, undefined, { numeric: true, sensitivity: 'base' }));
+                for (const [instance, instanceSources] of sortedHosts) {
                     const instanceDiv = document.createElement('div');
                     instanceDiv.className = 'instance-group';
                     instanceDiv.innerHTML = `<h3>${instance}</h3>`;


### PR DESCRIPTION
## Summary
- Sort devices within each subnet group by ascending IP address on the webpage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c9c57fdd8833194d1b08d1488741c